### PR TITLE
Fix Xcode 15 Compilation

### DIFF
--- a/PSOperations/Operation.swift
+++ b/PSOperations/Operation.swift
@@ -19,11 +19,16 @@ open class Operation: Foundation.Operation {
 
     private static var psoperationContext = 0
 
+#if swift(>=5.9)
+    public typealias CompletionBlock = @Sendable () -> Void
+#else
+    public typealias CompletionBlock = () -> Void
+#endif
     /* The completionBlock property has unexpected behaviors such as executing twice and executing on unexpected threads. BlockObserver
      * executes in an expected manner.
      */
     @available(*, deprecated, message: "use BlockObserver completions instead")
-    override open var completionBlock: (() -> Void)? {
+    override open var completionBlock: CompletionBlock? {
         get {
             return nil
         }


### PR DESCRIPTION
Use different CompletionBlock type, depending on the compiler version.
This compiles on both Xcode 14 and Xcode 15.